### PR TITLE
Bump cassandra version for spark compat

### DIFF
--- a/project/PhantomBuild.scala
+++ b/project/PhantomBuild.scala
@@ -7,7 +7,7 @@ object AnalyticsServer extends Build {
 
   val ScalaVersion = "2.10.4"
   val ScalaTestVersion = "2.1.0"
-  val datastaxDriverVersion = "2.1.1"
+  val datastaxDriverVersion = "2.1.3"
   val finagleVersion = "6.17.0"
 
   val publishSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
Spark has issues with lower versions of the datastax driver so moving
this along by a couple of patch releases is pretty helpful.
